### PR TITLE
fix: mixin config

### DIFF
--- a/common/src/main/resources/the_afterdark.mixins.json
+++ b/common/src/main/resources/the_afterdark.mixins.json
@@ -4,11 +4,13 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [],
-  "mixins": [
-    "DripstoneHelperMixin",
-    "PlayerEntityNBTMixin",
+  "server": [
     "MixinFireBlock",
     "MixinLavaFluid"
+  ],
+  "mixins": [
+    "DripstoneHelperMixin",
+    "PlayerEntityNBTMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
The commit 2a4138a implemented as a fix for #10 causes the client to crash when FireBlock or LavaFluid attempt to burn any blocks from GrassBlocks config option. This is due to the Client attempting to cast ClientLevel to ServerLevel.

This PR fixes the mixin config to only apply MixinFireBlock and MixinLavaFluid on the server.